### PR TITLE
Add PropTypes, React 16 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,13 @@
     "Joe Farro"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+  },
   "dependencies": {
     "invariant": "^2.0.0",
+    "prop-types": "^15.6.1",
     "warning": "^2.0.0"
   },
   "devDependencies": {
@@ -49,8 +54,6 @@
     "gzip-size": "^3.0.0",
     "isparta-loader": "^1.0.0",
     "pretty-bytes": "^2.0.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
     "rimraf": "^2.4.3",
     "style-loader": "^0.12.4",
     "webpack": "^1.4.13",

--- a/src/TxRegionsInput.js
+++ b/src/TxRegionsInput.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-
+import PropTypes from 'prop-types';
 import MarkedRanges from './MarkedRanges';
 import { markEmail, markUrls } from './markers';
 import { combineValidators } from './presets';
@@ -545,8 +545,6 @@ export default class TxRegionsInput extends Component {
         );
     }
 }
-
-const PropTypes = React.PropTypes;
 
 TxRegionsInput.propTypes = {
     defaultValue: PropTypes.string,


### PR DESCRIPTION
There's a number of errors that I received when attempting to run the tests and build the package, seemed likely due to version discrepancies so I can't confirm w/ certainty that this change does not introduce any breaking changes. But it shouldn't.

This PR replaces references to `React.PropTypes` with the `prop-types` package, and adds support for React 16. I've used the source version in my client's project without any errors.